### PR TITLE
feat(domain): add usecases and improve domain organization

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -44,7 +44,7 @@ dependencies {
 
     implementation "androidx.core:core-ktx:$kotlin_version"
     implementation 'androidx.appcompat:appcompat:1.5.1'
-    implementation 'com.google.android.material:material:1.6.1'
+    implementation 'com.google.android.material:material:1.7.0'
     implementation 'androidx.constraintlayout:constraintlayout:2.1.4'
 
     implementation "io.insert-koin:koin-android:$koin_version"
@@ -56,6 +56,9 @@ dependencies {
     testImplementation "io.mockk:mockk:$mockk_version"
     testImplementation "com.squareup.okhttp3:mockwebserver:$okhttp_version"
     testImplementation 'junit:junit:4.13.2'
+
+    testImplementation "io.insert-koin:koin-test:$koin_version"
+    testImplementation "io.insert-koin:koin-test-junit4:$koin_version"
 
     androidTestImplementation 'androidx.test.ext:junit:1.1.3'
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.4.0'

--- a/app/src/main/java/com/will/moviedbapp/core/usecase/UseCase.kt
+++ b/app/src/main/java/com/will/moviedbapp/core/usecase/UseCase.kt
@@ -1,0 +1,8 @@
+package com.will.moviedbapp.core.usecase
+
+import com.will.moviedbapp.core.state.StateResult
+import kotlinx.coroutines.flow.Flow
+
+abstract class UseCase<Param, Source> {
+    abstract suspend operator fun invoke(param: Param): Flow<StateResult<Source>>
+}

--- a/app/src/main/java/com/will/moviedbapp/data/datasource/movieDb/CMovieDBRemoteDataSource.kt
+++ b/app/src/main/java/com/will/moviedbapp/data/datasource/movieDb/CMovieDBRemoteDataSource.kt
@@ -1,7 +1,7 @@
 package com.will.moviedbapp.data.datasource.movieDb
 
 import com.will.moviedbapp.core.errors.RemoteDataSourceException
-import com.will.moviedbapp.data.model.Movie
+import com.will.moviedbapp.domain.model.Movie
 import com.will.moviedbapp.data.services.MovieDBService
 
 class CMovieDBRemoteDataSource(private val service: MovieDBService) : MovieDBRemoteDataSource {

--- a/app/src/main/java/com/will/moviedbapp/data/datasource/movieDb/MovieDBRemoteDataSource.kt
+++ b/app/src/main/java/com/will/moviedbapp/data/datasource/movieDb/MovieDBRemoteDataSource.kt
@@ -1,6 +1,6 @@
 package com.will.moviedbapp.data.datasource.movieDb
 
-import com.will.moviedbapp.data.model.Movie
+import com.will.moviedbapp.domain.model.Movie
 
 interface MovieDBRemoteDataSource {
     suspend fun getTrendingMovies(): List<Movie>

--- a/app/src/main/java/com/will/moviedbapp/data/repository/CMovieRepository.kt
+++ b/app/src/main/java/com/will/moviedbapp/data/repository/CMovieRepository.kt
@@ -2,7 +2,7 @@ package com.will.moviedbapp.data.repository
 
 import com.will.moviedbapp.core.state.StateResult
 import com.will.moviedbapp.data.datasource.movieDb.MovieDBRemoteDataSource
-import com.will.moviedbapp.data.model.Movie
+import com.will.moviedbapp.domain.model.Movie
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.catch
 import kotlinx.coroutines.flow.flow

--- a/app/src/main/java/com/will/moviedbapp/data/repository/MovieRepository.kt
+++ b/app/src/main/java/com/will/moviedbapp/data/repository/MovieRepository.kt
@@ -1,7 +1,7 @@
 package com.will.moviedbapp.data.repository
 
 import com.will.moviedbapp.core.state.StateResult
-import com.will.moviedbapp.data.model.Movie
+import com.will.moviedbapp.domain.model.Movie
 import kotlinx.coroutines.flow.Flow
 
 interface MovieRepository {

--- a/app/src/main/java/com/will/moviedbapp/data/services/MovieDBService.kt
+++ b/app/src/main/java/com/will/moviedbapp/data/services/MovieDBService.kt
@@ -1,7 +1,7 @@
 package com.will.moviedbapp.data.services
 
-import com.will.moviedbapp.data.model.Movie
-import com.will.moviedbapp.data.model.PaginatedResponse
+import com.will.moviedbapp.domain.model.Movie
+import com.will.moviedbapp.domain.model.PaginatedResponse
 import retrofit2.http.GET
 import retrofit2.http.Path
 import retrofit2.http.Query

--- a/app/src/main/java/com/will/moviedbapp/domain/model/Movie.kt
+++ b/app/src/main/java/com/will/moviedbapp/domain/model/Movie.kt
@@ -1,4 +1,4 @@
-package com.will.moviedbapp.data.model
+package com.will.moviedbapp.domain.model
 
 import com.google.gson.annotations.SerializedName
 

--- a/app/src/main/java/com/will/moviedbapp/domain/model/PaginatedResponse.kt
+++ b/app/src/main/java/com/will/moviedbapp/domain/model/PaginatedResponse.kt
@@ -1,4 +1,4 @@
-package com.will.moviedbapp.data.model
+package com.will.moviedbapp.domain.model
 
 import com.google.gson.annotations.SerializedName
 

--- a/app/src/main/java/com/will/moviedbapp/domain/usecase/GetMovieUseCase.kt
+++ b/app/src/main/java/com/will/moviedbapp/domain/usecase/GetMovieUseCase.kt
@@ -1,0 +1,13 @@
+package com.will.moviedbapp.domain.usecase
+
+import com.will.moviedbapp.core.state.StateResult
+import com.will.moviedbapp.core.usecase.UseCase
+import com.will.moviedbapp.data.repository.MovieRepository
+import com.will.moviedbapp.domain.model.Movie
+import kotlinx.coroutines.flow.Flow
+
+class GetMovieUseCase(private val repository: MovieRepository) : UseCase<Int, Movie>() {
+    override suspend fun invoke(param: Int): Flow<StateResult<Movie>> {
+        return repository.getMovie(param)
+    }
+}

--- a/app/src/main/java/com/will/moviedbapp/domain/usecase/GetTrendingMoviesUseCase.kt
+++ b/app/src/main/java/com/will/moviedbapp/domain/usecase/GetTrendingMoviesUseCase.kt
@@ -1,0 +1,13 @@
+package com.will.moviedbapp.domain.usecase
+
+import com.will.moviedbapp.core.state.StateResult
+import com.will.moviedbapp.core.usecase.UseCase
+import com.will.moviedbapp.data.repository.MovieRepository
+import com.will.moviedbapp.domain.model.Movie
+import kotlinx.coroutines.flow.Flow
+
+class GetTrendingMoviesUseCase(private val repository: MovieRepository) : UseCase<Unit, List<Movie>>() {
+    override suspend fun invoke(param: Unit): Flow<StateResult<List<Movie>>> {
+        return repository.getTrendingMovies()
+    }
+}

--- a/app/src/main/java/com/will/moviedbapp/domain/usecase/SearchUseCase.kt
+++ b/app/src/main/java/com/will/moviedbapp/domain/usecase/SearchUseCase.kt
@@ -1,0 +1,13 @@
+package com.will.moviedbapp.domain.usecase
+
+import com.will.moviedbapp.core.state.StateResult
+import com.will.moviedbapp.core.usecase.UseCase
+import com.will.moviedbapp.data.repository.MovieRepository
+import com.will.moviedbapp.domain.model.Movie
+import kotlinx.coroutines.flow.Flow
+
+class SearchUseCase(private val repository: MovieRepository) : UseCase<String, List<Movie>>() {
+    override suspend fun invoke(param: String): Flow<StateResult<List<Movie>>> {
+        return repository.search(param)
+    }
+}

--- a/app/src/test/java/com/will/moviedbapp/data/repository/CMovieRepositoryTest.kt
+++ b/app/src/test/java/com/will/moviedbapp/data/repository/CMovieRepositoryTest.kt
@@ -3,7 +3,7 @@ package com.will.moviedbapp.data.repository
 import com.will.moviedbapp.core.errors.RemoteDataSourceException
 import com.will.moviedbapp.core.state.StateResult
 import com.will.moviedbapp.data.datasource.movieDb.MovieDBRemoteDataSource
-import com.will.moviedbapp.data.model.Movie
+import com.will.moviedbapp.domain.model.Movie
 import com.will.moviedbapp.resources.mocks.MockMovie
 import io.mockk.MockKAnnotations
 import io.mockk.coEvery

--- a/app/src/test/java/com/will/moviedbapp/data/services/MovieDBServiceTest.kt
+++ b/app/src/test/java/com/will/moviedbapp/data/services/MovieDBServiceTest.kt
@@ -1,6 +1,6 @@
 package com.will.moviedbapp.data.services
 
-import com.will.moviedbapp.data.model.PaginatedResponse
+import com.will.moviedbapp.domain.model.PaginatedResponse
 import com.will.moviedbapp.resources.mocks.MockMovie
 import com.will.moviedbapp.resources.utils.enqueueResponse
 import kotlinx.coroutines.runBlocking

--- a/app/src/test/java/com/will/moviedbapp/domain/usecase/GetMovieUseCaseTest.kt
+++ b/app/src/test/java/com/will/moviedbapp/domain/usecase/GetMovieUseCaseTest.kt
@@ -1,0 +1,47 @@
+package com.will.moviedbapp.domain.usecase
+
+import com.will.moviedbapp.core.state.StateResult
+import com.will.moviedbapp.data.repository.MovieRepository
+import com.will.moviedbapp.domain.model.Movie
+import com.will.moviedbapp.resources.mocks.MockMovie
+import io.mockk.MockKAnnotations
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.impl.annotations.MockK
+import kotlinx.coroutines.flow.asFlow
+import kotlinx.coroutines.flow.toList
+import kotlinx.coroutines.runBlocking
+import org.junit.Before
+import org.junit.Test
+
+class GetMovieUseCaseTest {
+
+    @MockK
+    private lateinit var repository: MovieRepository
+    private lateinit var useCase: GetMovieUseCase
+
+    @Before
+    fun setUp() {
+        MockKAnnotations.init(this)
+        useCase = GetMovieUseCase(repository)
+    }
+
+    @Test
+    fun `should call execute method and returns normally`() {
+        val expectedState = listOf(
+            StateResult.Loading,
+            StateResult.Success<Movie>(MockMovie.movie),
+        )
+
+        coEvery { repository.getMovie(any()) } returns expectedState.asFlow()
+
+        runBlocking {
+            val flow = useCase(MockMovie.movieID)
+            val results = flow.toList()
+
+            kotlin.test.assertEquals(expectedState, results)
+            coVerify { repository.getMovie(any()) }
+        }
+    }
+
+}

--- a/app/src/test/java/com/will/moviedbapp/domain/usecase/GetTrendingMoviesUseCaseTest.kt
+++ b/app/src/test/java/com/will/moviedbapp/domain/usecase/GetTrendingMoviesUseCaseTest.kt
@@ -1,0 +1,50 @@
+package com.will.moviedbapp.domain.usecase
+
+import com.will.moviedbapp.core.state.StateResult
+import com.will.moviedbapp.data.repository.MovieRepository
+import com.will.moviedbapp.domain.model.Movie
+import com.will.moviedbapp.resources.mocks.MockMovie
+import io.mockk.MockKAnnotations
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.impl.annotations.MockK
+import kotlinx.coroutines.flow.asFlow
+import kotlinx.coroutines.flow.toList
+import kotlinx.coroutines.runBlocking
+import org.junit.Before
+import org.junit.Test
+import kotlin.test.assertEquals
+
+class GetTrendingMoviesUseCaseTest {
+
+    @MockK
+    private lateinit var repository: MovieRepository
+    private lateinit var useCase: GetTrendingMoviesUseCase
+
+    @Before
+    fun setUp() {
+        MockKAnnotations.init(this)
+        useCase = GetTrendingMoviesUseCase(repository)
+    }
+
+    @Test
+    fun `should call execute method and returns normally`() {
+        val listMovie = MockMovie.listMovie
+        val expectedState = listOf(
+            StateResult.Loading,
+            StateResult.Success<List<Movie>>(listMovie),
+        )
+
+        coEvery { repository.getTrendingMovies() } returns expectedState.asFlow()
+
+        runBlocking {
+            val flow = useCase(Unit)
+            val results = flow.toList()
+
+            assertEquals(expectedState, results)
+            coVerify { repository.getTrendingMovies() }
+        }
+
+    }
+
+}

--- a/app/src/test/java/com/will/moviedbapp/domain/usecase/SearchUseCaseTest.kt
+++ b/app/src/test/java/com/will/moviedbapp/domain/usecase/SearchUseCaseTest.kt
@@ -1,0 +1,50 @@
+package com.will.moviedbapp.domain.usecase
+
+import com.will.moviedbapp.core.state.StateResult
+import com.will.moviedbapp.data.repository.MovieRepository
+import com.will.moviedbapp.domain.model.Movie
+import com.will.moviedbapp.resources.mocks.MockMovie
+import io.mockk.MockKAnnotations
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.impl.annotations.MockK
+import kotlinx.coroutines.flow.asFlow
+import kotlinx.coroutines.flow.toList
+import kotlinx.coroutines.runBlocking
+import org.junit.Before
+import org.junit.Test
+import kotlin.test.assertEquals
+
+class SearchUseCaseTest {
+
+    @MockK
+    private lateinit var repository: MovieRepository
+    private lateinit var useCase: SearchUseCase
+
+    @Before
+    fun setUp() {
+        MockKAnnotations.init(this)
+        useCase = SearchUseCase(repository)
+    }
+
+    @Test
+    fun `should invoke useCase and returns normally`() {
+        val searchQuery = MockMovie.searchQuery
+        val listMovie = MockMovie.listMovie
+        val expectedState = listOf(
+            StateResult.Loading,
+            StateResult.Success<List<Movie>>(listMovie),
+        )
+
+        coEvery { repository.search(any()) } returns expectedState.asFlow()
+
+        runBlocking {
+            val flow = useCase(searchQuery)
+            val results = flow.toList()
+
+            assertEquals(expectedState, results)
+            coVerify { repository.search(any()) }
+        }
+    }
+
+}

--- a/app/src/test/java/com/will/moviedbapp/resources/mocks/MockMovie.kt
+++ b/app/src/test/java/com/will/moviedbapp/resources/mocks/MockMovie.kt
@@ -1,7 +1,7 @@
 package com.will.moviedbapp.resources.mocks
 
-import com.will.moviedbapp.data.model.Movie
-import com.will.moviedbapp.data.model.PaginatedResponse
+import com.will.moviedbapp.domain.model.Movie
+import com.will.moviedbapp.domain.model.PaginatedResponse
 
 object MockMovie {
     const val movieID = 438631


### PR DESCRIPTION
Este PR implementa:

1. Camada de domínio e os casos de uso que serão utilizados pela camada de apresentação;
2. Testes dos casos de uso;
3. As classes de modelos foram movidas da camada de dados para domínio;